### PR TITLE
feat: add request body access to security handlers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# Project: fastify-openapi3
+
+## Package Manager
+
+This project uses **pnpm**. Do not use npm or yarn.
+
+```bash
+pnpm install          # Install dependencies
+pnpm test             # Run tests
+pnpm lint             # Run linter
+pnpm lint --fix       # Auto-fix lint issues
+```
+
+## Project Overview
+
+A Fastify plugin for generating OpenAPI 3.1 specifications from route definitions using TypeBox schemas.
+
+## Key Commands
+
+- `pnpm test` - Run vitest test suite
+- `pnpm lint` - Run ESLint with Prettier
+- `pnpm build` - Build TypeScript
+- `pnpm demo` - Run example server
+
+## Architecture
+
+- `src/plugin.ts` - Main plugin entry point
+- `src/autowired-security/` - Security scheme handling (API key, HTTP Basic, Bearer)
+- `src/test/` - Test files (vitest)

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-prettier": "^5.2.1",
     "fastify": "^5",
+    "fastify-raw-body": "^5.0.0",
     "globals": "^15.10.0",
     "husky": "^9.1.5",
     "lint-staged": "^15.2.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       fastify:
         specifier: ^5
         version: 5.2.0
+      fastify-raw-body:
+        specifier: ^5.0.0
+        version: 5.0.0
       globals:
         specifier: ^15.10.0
         version: 15.10.0
@@ -794,6 +797,10 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -916,6 +923,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -1140,6 +1151,10 @@ packages:
   fastify-plugin@5.0.1:
     resolution: {integrity: sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==}
 
+  fastify-raw-body@5.0.0:
+    resolution: {integrity: sha512-2qfoaQ3BQDhZ1gtbkKZd6n0kKxJISJGM6u/skD9ljdWItAscjXrtZ1lnjr7PavmXX9j4EyCPmBDiIsLn07d5vA==}
+    engines: {node: '>= 10'}
+
   fastify@5.2.0:
     resolution: {integrity: sha512-3s+Qt5S14Eq5dCpnE0FxTp3z4xKChI83ZnMv+k0FwX+VUoZrgCFoLAxpfdi/vT4y6Mk+g7aAMt9pgXDoZmkefQ==}
 
@@ -1276,6 +1291,10 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
@@ -1284,6 +1303,10 @@ packages:
     resolution: {integrity: sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1299,6 +1322,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   internal-slot@1.0.7:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
@@ -1720,6 +1746,10 @@ packages:
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
   readable-stream@4.5.2:
     resolution: {integrity: sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1785,6 +1815,12 @@ packages:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+
   secure-json-parse@3.0.1:
     resolution: {integrity: sha512-9QR7G96th4QJ2+dJwvZB+JoXyt8PN+DbEjOr6kL2/JU4KH8Eb2sFdU+gt8EDdzWDWoWH0uocDdfCoFzdVSixUA==}
 
@@ -1810,6 +1846,9 @@ packages:
   set-function-name@2.0.2:
     resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1857,6 +1896,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
@@ -1963,6 +2006,10 @@ packages:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   ts-api-utils@1.3.0:
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
     engines: {node: '>=16'}
@@ -2022,6 +2069,10 @@ packages:
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   upper-case-first@2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
@@ -2790,6 +2841,8 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
 
   call-bind@1.0.7:
@@ -2925,6 +2978,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  depd@2.0.0: {}
 
   diff@4.0.2: {}
 
@@ -3243,6 +3298,12 @@ snapshots:
 
   fastify-plugin@5.0.1: {}
 
+  fastify-raw-body@5.0.0:
+    dependencies:
+      fastify-plugin: 5.0.1
+      raw-body: 3.0.2
+      secure-json-parse: 2.7.0
+
   fastify@5.2.0:
     dependencies:
       '@fastify/ajv-compiler': 4.0.1
@@ -3395,9 +3456,21 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   human-signals@5.0.0: {}
 
   husky@9.1.6: {}
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -3409,6 +3482,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   internal-slot@1.0.7:
     dependencies:
@@ -3837,6 +3912,13 @@ snapshots:
 
   quick-format-unescaped@4.0.4: {}
 
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
   readable-stream@4.5.2:
     dependencies:
       abort-controller: 3.0.0
@@ -3922,6 +4004,10 @@ snapshots:
 
   safe-stable-stringify@2.5.0: {}
 
+  safer-buffer@2.1.2: {}
+
+  secure-json-parse@2.7.0: {}
+
   secure-json-parse@3.0.1: {}
 
   semver@6.3.1: {}
@@ -3951,6 +4037,8 @@ snapshots:
       es-errors: 1.3.0
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.2
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -3995,6 +4083,8 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.7.0: {}
 
@@ -4096,6 +4186,8 @@ snapshots:
 
   toad-cache@3.7.0: {}
 
+  toidentifier@1.0.1: {}
+
   ts-api-utils@1.3.0(typescript@5.5.2):
     dependencies:
       typescript: 5.5.2
@@ -4175,6 +4267,8 @@ snapshots:
       which-boxed-primitive: 1.0.2
 
   undici-types@6.19.8: {}
+
+  unpipe@1.0.0: {}
 
   upper-case-first@2.0.2:
     dependencies:

--- a/src/autowired-security/index.ts
+++ b/src/autowired-security/index.ts
@@ -136,7 +136,9 @@ export function attachSecurityToRoute(
 
   // Add the security hook
   const existingPreValidationHooks = route.preValidation;
-  const newPreValidationHooks: Array<preValidationMetaHookHandler> = [hookHandler];
+  const newPreValidationHooks: Array<preValidationMetaHookHandler> = [
+    hookHandler,
+  ];
   if (Array.isArray(existingPreValidationHooks)) {
     newPreValidationHooks.push(
       ...existingPreValidationHooks.filter((f) => f !== hookHandler)

--- a/src/autowired-security/types/security-schemes.ts
+++ b/src/autowired-security/types/security-schemes.ts
@@ -3,28 +3,43 @@ import { type FastifyRequest } from "fastify";
 import { type HandlerRetval } from "./handlers.js";
 
 /**
+ * Context passed to security handlers that have `requiresParsedBody: true`.
+ * Contains the parsed request body, available because security handlers
+ * now run in the `preValidation` hook (after body parsing).
+ */
+export type SecurityHandlerContext = {
+  body: unknown;
+};
+
+/**
  * Primary handler type aliases.
+ * The optional third parameter `context` is provided when `requiresParsedBody: true`.
  */
 export type ApiKeyHandlerFn = (
   value: string,
-  request: FastifyRequest
+  request: FastifyRequest,
+  context?: SecurityHandlerContext
 ) => HandlerRetval | Promise<HandlerRetval>;
 export type HttpBasicHandlerFn = (
   credentials: { username: string; password: string },
-  request: FastifyRequest
+  request: FastifyRequest,
+  context?: SecurityHandlerContext
 ) => HandlerRetval | Promise<HandlerRetval>;
 export type HttpBearerFn = ApiKeyHandlerFn;
 
 /**
  * Secondary (nullable) handler type aliases.
+ * The optional third parameter `context` is provided when `requiresParsedBody: true`.
  */
 export type NullableApiKeyHandlerFn = (
   value: string | null,
-  request: FastifyRequest
+  request: FastifyRequest,
+  context?: SecurityHandlerContext
 ) => HandlerRetval | Promise<HandlerRetval>;
 export type NullableHttpBasicHandlerFn = (
   credentials: { username: string; password: string } | null,
-  request: FastifyRequest
+  request: FastifyRequest,
+  context?: SecurityHandlerContext
 ) => HandlerRetval | Promise<HandlerRetval>;
 export type NullableHttpBearerFn = NullableApiKeyHandlerFn;
 
@@ -40,11 +55,13 @@ export type ApiKeySecuritySchemeBase = {
 
 export type ApiKeySecuritySchemeStrict = ApiKeySecuritySchemeBase & {
   passNullIfNoneProvided?: false;
+  requiresParsedBody?: boolean;
   fn: ApiKeyHandlerFn;
 };
 
 export type ApiKeySecuritySchemeNullable = ApiKeySecuritySchemeBase & {
   passNullIfNoneProvided: true;
+  requiresParsedBody?: boolean;
   fn: NullableApiKeyHandlerFn;
 };
 
@@ -63,11 +80,13 @@ export type BasicAuthSecuritySchemeBase = {
 
 export type BasicAuthSecuritySchemeStrict = BasicAuthSecuritySchemeBase & {
   passNullIfNoneProvided?: false;
+  requiresParsedBody?: boolean;
   fn: HttpBasicHandlerFn;
 };
 
 export type BasicAuthSecuritySchemeNullable = BasicAuthSecuritySchemeBase & {
   passNullIfNoneProvided: true;
+  requiresParsedBody?: boolean;
   fn: NullableHttpBasicHandlerFn;
 };
 
@@ -86,11 +105,13 @@ export type BearerSecuritySchemeBase = {
 
 export type BearerSecuritySchemeStrict = BearerSecuritySchemeBase & {
   passNullIfNoneProvided?: false;
+  requiresParsedBody?: boolean;
   fn: HttpBearerFn;
 };
 
 export type BearerSecuritySchemeNullable = BearerSecuritySchemeBase & {
   passNullIfNoneProvided: true;
+  requiresParsedBody?: boolean;
   fn: NullableHttpBearerFn;
 };
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,6 +1,6 @@
 import OpenAPISchemaValidator from "@seriousme/openapi-schema-validator";
 import { type RouteOptions } from "fastify";
-import { type onRequestMetaHookHandler } from "fastify/types/hooks.js";
+import { type preValidationMetaHookHandler } from "fastify/types/hooks.js";
 import { fastifyPlugin } from "fastify-plugin";
 import * as YAML from "js-yaml";
 import { cloneDeep } from "lodash-es";
@@ -68,7 +68,7 @@ export const oas3Plugin = fastifyPlugin<OAS3PluginOptions>(
     // object-munging business during `onReady`.
     const routes: Array<RouteOptions> = [];
     fastify.addHook("onRoute", async (route) => {
-      const hookCache: Record<string, onRequestMetaHookHandler> = {};
+      const hookCache: Record<string, preValidationMetaHookHandler> = {};
 
       const rLog = pLog.child({
         route: { url: route.url, method: route.method },

--- a/src/test/autowired-security.spec.ts
+++ b/src/test/autowired-security.spec.ts
@@ -1350,7 +1350,9 @@ describe("autowired security", () => {
                 requiresParsedBody: true,
                 fn: (value, request, context) => {
                   receivedBody = context?.body;
-                  return value === "test" ? { ok: true } : { ok: false, code: 401 };
+                  return value === "test"
+                    ? { ok: true }
+                    : { ok: false, code: 401 };
                 },
               },
             },
@@ -1401,7 +1403,9 @@ describe("autowired security", () => {
                 requiresParsedBody: false,
                 fn: (value, request, context) => {
                   receivedContext = context;
-                  return value === "test" ? { ok: true } : { ok: false, code: 401 };
+                  return value === "test"
+                    ? { ok: true }
+                    : { ok: false, code: 401 };
                 },
               },
             },
@@ -1449,7 +1453,9 @@ describe("autowired security", () => {
                 name: "X-Api-Key",
                 requiresParsedBody: true,
                 fn: (value, request, context) => {
-                  const body = context?.body as { allowAccess?: boolean } | undefined;
+                  const body = context?.body as
+                    | { allowAccess?: boolean }
+                    | undefined;
                   if (value !== "test") return { ok: false, code: 401 };
                   if (!body?.allowAccess) return { ok: false, code: 403 };
                   return { ok: true };
@@ -1527,7 +1533,9 @@ describe("autowired security", () => {
                 requiresParsedBody: true,
                 fn: (token, request, context) => {
                   receivedBody = context?.body;
-                  return token === "valid" ? { ok: true } : { ok: false, code: 401 };
+                  return token === "valid"
+                    ? { ok: true }
+                    : { ok: false, code: 401 };
                 },
               },
             },
@@ -1552,7 +1560,7 @@ describe("autowired security", () => {
           method: "POST",
           path: "/test",
           headers: {
-            Authorization: "Bearer valid",
+            "Authorization": "Bearer valid",
             "Content-Type": "application/json",
           },
           payload: { message: "hello world" },
@@ -1606,7 +1614,8 @@ describe("autowired security", () => {
           method: "POST",
           path: "/test",
           headers: {
-            Authorization: "Basic " + Buffer.from("user:pass").toString("base64"),
+            "Authorization":
+              "Basic " + Buffer.from("user:pass").toString("base64"),
             "Content-Type": "application/json",
           },
           payload: { value: 42 },
@@ -1638,7 +1647,9 @@ describe("autowired security", () => {
                   receivedValue = value;
                   receivedBody = context?.body;
                   // Allow if no key provided but body has special flag
-                  const body = context?.body as { anonymous?: boolean } | undefined;
+                  const body = context?.body as
+                    | { anonymous?: boolean }
+                    | undefined;
                   if (value === null && body?.anonymous) return { ok: true };
                   if (value === "test") return { ok: true };
                   return { ok: false, code: 401 };
@@ -1701,7 +1712,9 @@ describe("autowired security", () => {
                 name: "X-Regular-Key",
                 fn: (value) => {
                   regularHandlerCalled = true;
-                  return value === "regular" ? { ok: true } : { ok: false, code: 401 };
+                  return value === "regular"
+                    ? { ok: true }
+                    : { ok: false, code: 401 };
                 },
               },
               BodyKey: {
@@ -1782,7 +1795,9 @@ describe("autowired security", () => {
                 in: "header",
                 name: "X-Regular-Key",
                 fn: (value) => {
-                  return value === "regular" ? { ok: true } : { ok: false, code: 401 };
+                  return value === "regular"
+                    ? { ok: true }
+                    : { ok: false, code: 401 };
                 },
               },
               BodyKey: {
@@ -1894,7 +1909,9 @@ describe("autowired security", () => {
           in: "header",
           name: "X-Body-Key",
         });
-        expect(jsonDoc.components.securitySchemes.BodyKey.requiresParsedBody).toBeUndefined();
+        expect(
+          jsonDoc.components.securitySchemes.BodyKey.requiresParsedBody
+        ).toBeUndefined();
         expect(jsonDoc.components.securitySchemes.BodyKey.fn).toBeUndefined();
       });
     });


### PR DESCRIPTION
## Summary

- Move security handlers from `onRequest` to `preValidation` hook, enabling access to parsed request bodies
- Add `requiresParsedBody` option to security schemes - when `true`, handlers receive a `context` parameter with the parsed body
- Backward compatible: existing handlers work unchanged (context is `undefined` when not requested)

## Changes

- **Hook migration**: Security handlers now run in `preValidation` instead of `onRequest`
- **New types**: `SecurityHandlerContext` with `body: unknown`, optional `requiresParsedBody` on all scheme types
- **Handler updates**: All three handler builders (`buildApiKeyHandler`, `buildHttpBasicHandler`, `buildHttpBearerHandler`) pass context when requested
- **Documentation**: Added comprehensive autowired security section to README

## Test plan

- [x] All 62 existing tests pass (no regressions from hook change)
- [x] 9 new tests for `requiresParsedBody` feature:
  - Body access for API Key, HTTP Bearer, HTTP Basic schemes
  - Combined with `passNullIfNoneProvided`
  - AND/OR security logic with body-aware handlers
  - Verification that `requiresParsedBody` is stripped from OpenAPI doc