### PR TITLE
fix: extract nested schemaTypes from arrays in Fastify routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eropple/fastify-openapi3",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Ed Ropple",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Fixes a bug where nested `schemaType`-wrapped schemas inside `Type.Array` were not being extracted to `components/schemas` when used in Fastify routes.

**Example that was broken:**
```typescript
const Inner = schemaType("Inner", Type.Object({ foo: Type.String() }));
const Outer = schemaType("Outer", Type.Object({ 
  items: Type.Array(Inner)  // Inner was not extracted!
}));
```

## Root Cause

`findTaggedSchemasInSchemas` used TypeBox's `Type.IsArray()` to detect array schemas. However, `Type.IsArray()` relies on an internal `~kind` property that Fastify strips during schema processing. This caused the array detection to fail, so nested schemas within arrays were never discovered.

## Fix

Replace `Type.IsArray(s)` with a direct JSON Schema check: `s.type === 'array' && s.items !== undefined`. This approach works regardless of whether TypeBox's internal metadata is present.

## Test Plan

- [x] Added test for basic nested schemaType in arrays
- [x] Added test for deeply nested arrays (array of arrays)
- [x] Added test for nullable arrays via `Type.Union`
- [x] Added test that schema symbols survive route handler processing
- [x] All 80 tests pass